### PR TITLE
fix signature_backend_choices()

### DIFF
--- a/django_anysign/models.py
+++ b/django_anysign/models.py
@@ -1,5 +1,4 @@
-from django_anysign import settings
-
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 


### PR DESCRIPTION
`signature_backend_choices()` was returning an empty list, because it was referencing `django_anysign.settings.ANYSIGN['BACKENDS']`, which is empty, rather than Django's runtime settings.