### PR TITLE
Updated signing_order help_text

### DIFF
--- a/django_anysign/models.py
+++ b/django_anysign/models.py
@@ -176,7 +176,7 @@ def SignerFactory(Signature):
         signing_order = models.PositiveSmallIntegerField(
             _('signing order'),
             default=0,
-            help_text=_('Position in the list of signers. Starts at 1.'))
+            help_text=_('Position in the list of signers.'))
 
         #: Identifier in backend's external database.
         signature_backend_id = models.CharField(


### PR DESCRIPTION
Given that the default is 0 for a PositiveSmallIntegerField, it is incorrect to say the signing order starts at 1.