### PR TITLE
Explicit on_delete behaviour for ForeignKeys.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ about future releases, check `milestones`_ and :doc:`/about/vision`.
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add explicit on_delete on ForeignKeys.
 
 
 1.1 (2017-03-24)

--- a/django_anysign/models.py
+++ b/django_anysign/models.py
@@ -105,7 +105,8 @@ def SignatureFactory(SignatureType):
         #: Type of the signature, i.e. a backend and its configuration.
         signature_type = models.ForeignKey(
             SignatureType,
-            verbose_name=_('signature type'))
+            verbose_name=_('signature type'),
+            on_delete=models.CASCADE)
 
         #: Identifier in backend's external database.
         signature_backend_id = models.CharField(
@@ -168,7 +169,8 @@ def SignerFactory(Signature):
         #: Signature.
         signature = models.ForeignKey(
             Signature,
-            related_name='signers')
+            related_name='signers',
+            on_delete=models.CASCADE)
 
         #: Position as a signer.
         signing_order = models.PositiveSmallIntegerField(

--- a/django_anysign/models.py
+++ b/django_anysign/models.py
@@ -91,7 +91,8 @@ class SignatureType(models.Model):
             return self._signature_backend
 
 
-def SignatureFactory(SignatureType):
+def SignatureFactory(SignatureType, on_stype_delete=models.CASCADE):
+
     """Return base class for signature model, using ``SignatureType`` model.
 
     This pattern is the best one we found at the moment to have an abstract
@@ -99,6 +100,8 @@ def SignatureFactory(SignatureType):
     ``SignatureType`` model. Feel free to propose a better option if you know
     one ;)
 
+    :param SignatureType: concrete SignatureType model
+    :param on_stype_delete: on_delete SignatureType ForeignKey behaviour
     """
     class Signature(models.Model):
         """Base model for signature models."""
@@ -106,7 +109,7 @@ def SignatureFactory(SignatureType):
         signature_type = models.ForeignKey(
             SignatureType,
             verbose_name=_('signature type'),
-            on_delete=models.CASCADE)
+            on_delete=on_stype_delete)
 
         #: Identifier in backend's external database.
         signature_backend_id = models.CharField(
@@ -151,13 +154,15 @@ def SignatureFactory(SignatureType):
     return Signature
 
 
-def SignerFactory(Signature):
+def SignerFactory(Signature, on_signature_delete=models.CASCADE):
     """Return base class for signer model, using ``Signature`` model.
 
     This pattern is the best one we found at the moment to have an abstract
     base model ``Signer`` with appropriate foreign key to ``Signature``
     model. Feel free to propose a better option if you know one ;)
 
+    :param Signature: concrete Signature model
+    :param on_signature_delete: on_delete Signature ForeignKey behaviour
     """
     class Signer(models.Model):
         """Base class for signer.
@@ -170,7 +175,7 @@ def SignerFactory(Signature):
         signature = models.ForeignKey(
             Signature,
             related_name='signers',
-            on_delete=models.CASCADE)
+            on_delete=on_signature_delete)
 
         #: Position as a signer.
         signing_order = models.PositiveSmallIntegerField(


### PR DESCRIPTION
RemovedInDjango20Warning: on_delete will be a required arg for ForeignKey in Django 2.0.
Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior.
See https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.on_delete